### PR TITLE
ManifestReader: report when no data was read

### DIFF
--- a/implementations/manifest-factory/loader.py
+++ b/implementations/manifest-factory/loader.py
@@ -83,12 +83,16 @@ class ManifestReader(object):
 	def get_warnings(self):
 		if self.debug_stream:
 			self.debug_stream.seek(0)
-			return self.debug_stream.readlines()	
+			return self.debug_stream.readlines()
 		else:
 			return []
 
 	def read(self):
 		data = self.data
+
+		if not data:
+			raise SerializationError('Data was empty', data)
+
 		if type(data) in [dict, OrderedDict]:
 			js = data
 		else:


### PR DESCRIPTION
Previously attempts to load an empty response would return
a string index out of range error in the JSON error-handling
path when it tried to trim a malformed UTF-8 BOM.

This can be simulated using httpbin.org:

http://iiif.io/api/presentation/validator/service/validate?url=http%3A%2F%2Fhttpbin.org%2Fstatus%2F503&version=2.0&format=html

“Validation Error: string index out of range”
