### PR TITLE
No longer need to ignore contexts as included in iiif-prezi package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/contexts
+.cache

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -8,7 +8,7 @@ from bottle import Response
 # the classes within
 fh = open('iiif-presentation-validator.py', 'r')
 try:
-    val_mod = imp.load_module('ipv', fh, '', ('py','r',imp.PY_SOURCE))
+    val_mod = imp.load_module('ipv', fh, '.', ('py','r',imp.PY_SOURCE))
 finally:
     fh.close()
 


### PR DESCRIPTION
won't have to copy /contexts in anymore so no need to exclude