### PR TITLE
Extra ignores for pyc and egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .c
 .coverage
 *.egg
+*.egg-info
 .eggs
 build
 __pycache__
 htmlcov
+*.pyc


### PR DESCRIPTION
Replaces IIIF/presentation-validator#50 with something on a branch that doesn't trigger travis deploy failure for py3.4... I hope