### PR TITLE
URL return and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .c
 .coverage
 *.egg
+*.egg-info
 .eggs
 build
 __pycache__
 htmlcov
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - python setup.py install
   - pip install coveralls
 script:
   - python setup.py test
-  - coverage run --omit=tests/*,setup.py,*.egg --include=iiif-presentation-validator.py setup.py test
+  - coverage run --include=iiif-presentation-validator.py setup.py test
 after_success:
   - coveralls
 before_deploy:

--- a/iiif-presentation-validator.py
+++ b/iiif-presentation-validator.py
@@ -132,7 +132,7 @@ class Validator(object):
                             ' header does not include Accept-Encoding, which'
                             ' can cause compatibility issues')
 
-        return self.check_manifest(data, version, warnings)
+        return self.check_manifest(data, version, url, warnings)
 
     def index_route(self):
         """Read and return index page."""


### PR DESCRIPTION
I noticed while looking into https://github.com/IIIF/iiif.io/issues/1142 I noticed that the validator output had:

> Validation Results:
>
> URL Tested: None

where it should have shown the URL being tested. Seems that this had been broken between the current live version and the current master. This PR fixes that so should be merged before the live version is updated.

Also tidied http/https test, fixed test setup for mocking requests, and some tidy. Added py3.6 to travis tests too.