### PR TITLE
Reading in index.html as a uft-8 file

### DIFF
--- a/iiif-presentation-validator.py
+++ b/iiif-presentation-validator.py
@@ -105,7 +105,7 @@ class Validator(object):
         return self.check_manifest(data, version, warnings)
 
     def index_route(self):
-        with open(os.path.join(os.path.dirname(__file__),'index.html'), 'r') as fh:
+        with open(os.path.join(os.path.dirname(__file__),'index.html'), 'r', encoding='utf-8') as fh:
             data = fh.read()
         return data
 

--- a/iiif-presentation-validator.py
+++ b/iiif-presentation-validator.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import sys
+import codecs
 try:
     # python3
     from urllib.request import urlopen, HTTPError
@@ -105,7 +106,7 @@ class Validator(object):
         return self.check_manifest(data, version, warnings)
 
     def index_route(self):
-        with open(os.path.join(os.path.dirname(__file__),'index.html'), 'r', encoding='utf-8') as fh:
+        with codecs.open(os.path.join(os.path.dirname(__file__),'index.html'), 'r', 'utf-8') as fh:
             data = fh.read()
         return data
 


### PR DESCRIPTION
I believe this is causing the following to fail:

http://presentation-validator.iiif.io/

due to the following error in the log:

```
which: no identify in (/opt/python/run/venv/bin/:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin)
[Fri Aug 25 01:10:24.015160 2017] [:error] [pid 7012] [remote 172.31.86.71:58080] Traceback (most recent call last):
[Fri Aug 25 01:10:24.015189 2017] [:error] [pid 7012] [remote 172.31.86.71:58080]   File "/opt/python/run/venv/lib/python3.4/site-packages/bottle.py", line 862, in _handle
[Fri Aug 25 01:10:24.015193 2017] [:error] [pid 7012] [remote 172.31.86.71:58080]     return route.call(**args)
[Fri Aug 25 01:10:24.015196 2017] [:error] [pid 7012] [remote 172.31.86.71:58080]   File "/opt/python/run/venv/lib/python3.4/site-packages/bottle.py", line 1740, in wrapper
[Fri Aug 25 01:10:24.015198 2017] [:error] [pid 7012] [remote 172.31.86.71:58080]     rv = callback(*a, **ka)
[Fri Aug 25 01:10:24.015200 2017] [:error] [pid 7012] [remote 172.31.86.71:58080]   File "/opt/python/current/app/iiif-presentation-validator.py", line 109, in index_route
[Fri Aug 25 01:10:24.015203 2017] [:error] [pid 7012] [remote 172.31.86.71:58080]     data = fh.read()
[Fri Aug 25 01:10:24.015205 2017] [:error] [pid 7012] [remote 172.31.86.71:58080]   File "/opt/python/run/baselinenv/lib64/python3.4/encodings/ascii.py", line 26, in decode
[Fri Aug 25 01:10:24.015208 2017] [:error] [pid 7012] [remote 172.31.86.71:58080]     return codecs.ascii_decode(input, self.errors)[0]
[Fri Aug 25 01:10:24.015210 2017] [:error] [pid 7012] [remote 172.31.86.71:58080] UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 597: ordinal not in range(128)
which: no identify in (/opt/python/run/venv/bin/:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin)
```
The fix is to read in the file as a utf-8 file. 