### PR TITLE
typo languagae -> language in 3.0 json schema

### DIFF
--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -10,7 +10,7 @@
         },
         "lngString": {
             "$id": "#lngString",
-            "title": "Language string, must have a languagae and value must be an array.",
+            "title": "Language string, must have a language and value must be an array.",
             "type": "object",
             "patternProperties": {
                 "^[a-zA-Z-][a-zA-Z-]*$": {


### PR DESCRIPTION
I noticed a typo in the schema when using the online validator. Should I also open an issue when correcting a typo?

 Thanks for the work on IIIF!