### PR TITLE
Added checks for v3 Creative Commons licenses

### DIFF
--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -241,6 +241,36 @@
                 {
                     "type": "string",
                     "format": "uri",
+                    "pattern": "http://creativecommons.org/licenses/by/3.0"
+                },
+                {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "http://creativecommons.org/licenses/by-sa/3.0"
+                },
+                {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "http://creativecommons.org/licenses/by-nd/3.0"
+                },
+                {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "http://creativecommons.org/licenses/by-nc/3.0"
+                },
+                {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "http://creativecommons.org/licenses/by-nc-sa/3.0"
+                },
+                {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "http://creativecommons.org/licenses/by-nc-nd/3.0"
+                },
+                {
+                    "type": "string",
+                    "format": "uri",
                     "pattern": "http://creativecommons.org/licenses/by/4.0"
                 },
                 {


### PR DESCRIPTION
Blunt way of addressing #90 and, consequently, failures in cookbook recipes that rely on resources with Creative Commons v3 licensing.