### PR TITLE
Add User-Agent to request header

### DIFF
--- a/iiif-presentation-validator.py
+++ b/iiif-presentation-validator.py
@@ -37,6 +37,7 @@ class Validator(object):
     def fetch(self, url):
         """Fetch manifest from url."""
         req = Request(url)
+        req.add_header('User-Agent', 'IIIF Validation Service')
         req.add_header('Accept-Encoding', 'gzip')
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class Coverage(Command):
 
 setup(
     name='iiif-presentation-validator',
-    version='0.0.2',
+    version='0.0.3',
     scripts=['iiif-presentation-validator.py'],
     classifiers=["Development Status :: 4 - Beta",
                  "Intended Audience :: Developers",


### PR DESCRIPTION
Adds a User-Agent request header for services (like Cloudflare) that reject traffic that doesn't identify itself.

Bumps semantic version to `0.0.3`

#92