### PR TITLE
Loosening the test for valid license URIs

### DIFF
--- a/fixtures/3/non_cc_license.json
+++ b/fixtures/3/non_cc_license.json
@@ -1,0 +1,64 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:4000/recipe/0008-rights/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Picture of Göttingen taken during the 2019 IIIF Conference"
+    ]
+  },
+  "summary": {
+    "en": [
+      "<p>Picture taken by the <a href=\"https://github.com/glenrobson\">IIIF Technical Coordinator</a></p>"
+    ]
+  },
+  "rights": "https://en.wikipedia.org/wiki/License",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Attribution"
+      ]
+    },
+    "value": {
+      "en": [
+        "<span>Glen Robson, IIIF Technical Coordinator. <a href=\"https://creativecommons.org/licenses/by-sa/3.0\">CC BY-SA 3.0</a> <img src=\"https://licensebuttons.net/l/by-sa/3.0/88x31.png\"/></span>"
+      ]
+    }
+  },
+  "items": [
+    {
+      "id": "http://localhost:4000/recipe/0008-rights/canvas/p1",
+      "type": "Canvas",
+      "height": 3024,
+      "width": 4032,
+      "items": [
+        {
+          "id": "http://localhost:4000/recipe/0008-rights/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:4000/recipe/0008-rights/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3024,
+                "width": 4032,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
+                    "profile": "level1",
+                    "type": "ImageService3"
+                  }
+                ]
+              },
+              "target": "http://localhost:4000/recipe/0008-rights/canvas/p1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/3/old_cc_license.json
+++ b/fixtures/3/old_cc_license.json
@@ -1,0 +1,64 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:4000/recipe/0008-rights/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Picture of Göttingen taken during the 2019 IIIF Conference"
+    ]
+  },
+  "summary": {
+    "en": [
+      "<p>Picture taken by the <a href=\"https://github.com/glenrobson\">IIIF Technical Coordinator</a></p>"
+    ]
+  },
+  "rights": "http://creativecommons.org/licenses/by-sa/3.0/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Attribution"
+      ]
+    },
+    "value": {
+      "en": [
+        "<span>Glen Robson, IIIF Technical Coordinator. <a href=\"https://creativecommons.org/licenses/by-sa/3.0\">CC BY-SA 3.0</a> <img src=\"https://licensebuttons.net/l/by-sa/3.0/88x31.png\"/></span>"
+      ]
+    }
+  },
+  "items": [
+    {
+      "id": "http://localhost:4000/recipe/0008-rights/canvas/p1",
+      "type": "Canvas",
+      "height": 3024,
+      "width": 4032,
+      "items": [
+        {
+          "id": "http://localhost:4000/recipe/0008-rights/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:4000/recipe/0008-rights/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3024,
+                "width": 4032,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
+                    "profile": "level1",
+                    "type": "ImageService3"
+                  }
+                ]
+              },
+              "target": "http://localhost:4000/recipe/0008-rights/canvas/p1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/3/rightsstatement_license.json
+++ b/fixtures/3/rightsstatement_license.json
@@ -1,0 +1,64 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:4000/recipe/0008-rights/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Picture of Göttingen taken during the 2019 IIIF Conference"
+    ]
+  },
+  "summary": {
+    "en": [
+      "<p>Picture taken by the <a href=\"https://github.com/glenrobson\">IIIF Technical Coordinator</a></p>"
+    ]
+  },
+  "rights": "http://rightsstatements.org/vocab/NoC-NC/1.0/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Attribution"
+      ]
+    },
+    "value": {
+      "en": [
+        "<span>Glen Robson, IIIF Technical Coordinator. <a href=\"https://creativecommons.org/licenses/by-sa/3.0\">CC BY-SA 3.0</a> <img src=\"https://licensebuttons.net/l/by-sa/3.0/88x31.png\"/></span>"
+      ]
+    }
+  },
+  "items": [
+    {
+      "id": "http://localhost:4000/recipe/0008-rights/canvas/p1",
+      "type": "Canvas",
+      "height": 3024,
+      "width": 4032,
+      "items": [
+        {
+          "id": "http://localhost:4000/recipe/0008-rights/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:4000/recipe/0008-rights/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3024,
+                "width": 4032,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
+                    "profile": "level1",
+                    "type": "ImageService3"
+                  }
+                ]
+              },
+              "target": "http://localhost:4000/recipe/0008-rights/canvas/p1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -236,7 +236,7 @@
             }
         },
         "rights": {
-            "title": "Rights URI isn't from either Creative Commons or Rights statements.org. Both require http links.",
+            "title": "Rights URI isn't from either Creative Commons or RightsStatements.org. Both require http links.",
             "oneOf": [
                 {
                     "type": "string",

--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -241,97 +241,17 @@
                 {
                     "type": "string",
                     "format": "uri",
-                    "pattern": "http://creativecommons.org/licenses/by/4.0"
+                    "pattern": "http://creativecommons.org/licenses/.*"
                 },
                 {
                     "type": "string",
                     "format": "uri",
-                    "pattern": "http://creativecommons.org/licenses/by-sa/4.0"
+                    "pattern": "http://creativecommons.org/publicdomain/mark/.*"
                 },
                 {
                     "type": "string",
                     "format": "uri",
-                    "pattern": "http://creativecommons.org/licenses/by-nd/4.0"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://creativecommons.org/licenses/by-nc/4.0"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://creativecommons.org/licenses/by-nc-sa/4.0"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://creativecommons.org/licenses/by-nc-nd/4.0"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://creativecommons.org/publicdomain/mark/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/InC/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/InC-OW-EU/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/InC-EDU/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/InC-NC/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/InC-RUU/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/NoC-CR/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/NoC-NC/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/NoC-OKLR/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/NoC-US/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/CNE/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/UND/1.0/"
-                },
-                {
-                    "type": "string",
-                    "format": "uri",
-                    "pattern": "http://rightsstatements.org/vocab/NKC/1.0/"
+                    "pattern": "http://rightsstatements.org/vocab/.*"
                 }
             ]
         },

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -138,7 +138,9 @@ class TestAll(unittest.TestCase):
                      'fixtures/3/version2image.json',
                      'fixtures/3/annoPage.json',
                      'fixtures/3/anno_pointselector.json',
-                     'fixtures/3/annoPageMultipleMotivations.json'
+                     'fixtures/3/annoPageMultipleMotivations.json',
+                     'fixtures/3/old_cc_license.json',
+                     'fixtures/3/rightsstatement_license.json'
                      ]:
             with open(good, 'r') as fh:
                 data = fh.read()
@@ -151,7 +153,8 @@ class TestAll(unittest.TestCase):
         for bad_data in ['fixtures/3/broken_simple_image.json',
                          'fixtures/3/broken_choice.json',
                          'fixtures/3/broken_collection.json',
-                         'fixtures/3/broken_embedded_annos.json']:
+                         'fixtures/3/broken_embedded_annos.json',
+                         'fixtures/3/non_cc_license.json']:
             with open(bad_data, 'r') as fh:
                 data = fh.read()
                 j = json.loads(v.check_manifest(data, '3.0'))


### PR DESCRIPTION
Allow different versions of creative commons license statement while retaining a test to ensure the following:

https://iiif.io/api/presentation/3.0/#rights

"The value must be drawn from the set of Creative Commons license URIs, the RightsStatements.org rights statement URIs"