### PR TITLE
Fixing 2.0 validation

### DIFF
--- a/iiif-presentation-validator.py
+++ b/iiif-presentation-validator.py
@@ -26,7 +26,8 @@ egg_cache = "/path/to/web/egg_cache"
 os.environ['PYTHON_EGG_CACHE'] = egg_cache
 
 from iiif_prezi.loader import ManifestReader
-
+from pyld import jsonld
+jsonld.set_document_loader(jsonld.requests_document_loader(timeout=60))
 
 class Validator(object):
     """Validator class that runs with Bottle."""
@@ -84,6 +85,7 @@ class Validator(object):
                 okay = 1
             except Exception as e:
                 # Failed
+                print (e)
                 err = e
                 okay = 0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ iiif_prezi
 jsonschema
 mock
 jsonpath-rw
+requests

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             "Pillow==6.2.2",
             "zipp==1.2.0",
             "configparser==4.0.2",
-            "pyld=1.0.5"
+            "pyld==1.0.5"
         ],
     },
     test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(
         'bottle>=0.12.9',
         'iiif_prezi>=0.2.2',
         'jsonschema',
-        'jsonpath_rw'
+        'jsonpath_rw',
+        'requests'
     ],
     extras_require={
         ':python_version>="3.0"': ["Pillow>=3.2.0"],

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
         ':python_version<"3.0"': [
             "Pillow==6.2.2",
             "zipp==1.2.0",
-            "configparser==4.0.2"
+            "configparser==4.0.2",
+            "pyld=1.0.5"
         ],
     },
     test_suite="tests",


### PR DESCRIPTION
Using requests JSON-LD document loader as current iiif-prezi
document loaded isn't working with latest pyld due to missing
parameters in the method.