### PR TITLE
Added missing services property to validator

### DIFF
--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -371,6 +371,7 @@
                         "navDate": { "$ref": "#/classes/navDate" },
                         "provider": { "$ref": "#/classes/provider" },
                         "seeAlso": { "$ref": "#/classes/seeAlso" },
+                        "services": { "$ref": "#/classes/service" },
                         "thumbnail": {
                             "type": "array",
                             "items": { "$ref": "#/classes/resource" }
@@ -432,6 +433,7 @@
                         "requiredStatement": { "$ref": "#/types/keyValueString" },
                         "rendering": { "$ref": "#/types/external" },
                         "service": { "$ref": "#/classes/service" },
+                        "services": { "$ref": "#/classes/service" },
                         "viewingDirection": { "$ref": "#/classes/viewingDirection" },
                         "rights": { "$ref": "#/classes/rights" },
                         "start": {},


### PR DESCRIPTION
As per: https://iiif.io/api/presentation/3.0/#table-reqs-3 Manifests and Collections may have a `services` property containing an array of services.