### PR TITLE
A class for references to manifests inside collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ __pycache__
 htmlcov
 *.pyc
 *.swp
-
-.DS_Store

--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -359,6 +359,7 @@
                         "type": {
                             "type": "string",
                             "pattern": "^Collection",
+                            "default":"Collection",
                             "title": "Are you validating a collection?",
                             "description":"If you are validating a manifest, you may get this error if there are errors in the manifest. The validator first validates it as a manifest and if that fails it will try and validate it using the other types."
                         },
@@ -501,6 +502,10 @@
                         "type": {
                             "type": "string",
                             "pattern": "^Manifest"
+                        },
+                        "thumbnail": {
+                            "type": "array",
+                            "items": { "$ref": "#/classes/resource" }
                         }
                     },
                     "required": ["id", "type", "label"]

--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -381,7 +381,7 @@
                             "type": "array",
                             "items": {
                               "oneOf": [
-                                { "$ref": "#/classes/manifest" },
+                                { "$ref": "#/classes/refmanifest" },
                                 { "$ref": "#/classes/collection" }
                               ]
                             }
@@ -466,6 +466,41 @@
                             "items": {
                                 "$ref": "#/classes/annotationPage"
                             }
+                        }
+                    },
+                    "required": ["id", "type", "label"]
+                }
+            ]
+        },
+        "refmanifest": {
+            "allOf": [
+                { "$ref": "#/types/class" },
+                {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "@context": {
+                            "oneOf": [
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "pattern": "^http.*$",
+                                        "description":"refmanifest is used for referencing manifests inside collections."
+                                    }
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "http://iiif.io/api/presentation/3/context.json"
+                                }
+                            ]
+                        },
+                        "id": { "$ref": "#/types/id" },
+                        "label": {"$ref": "#/types/lngString" },
+                        "type": {
+                            "type": "string",
+                            "pattern": "^Manifest"
                         }
                     },
                     "required": ["id", "type", "label"]

--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -359,7 +359,6 @@
                         "type": {
                             "type": "string",
                             "pattern": "^Collection",
-                            "default":"Collection",
                             "title": "Are you validating a collection?",
                             "description":"If you are validating a manifest, you may get this error if there are errors in the manifest. The validator first validates it as a manifest and if that fails it will try and validate it using the other types."
                         },
@@ -473,7 +472,7 @@
                 }
             ]
         },
-        "refmanifest": {
+        "reference": {
             "allOf": [
                 { "$ref": "#/types/class" },
                 {
@@ -488,7 +487,7 @@
                                         "type": "string",
                                         "format": "uri",
                                         "pattern": "^http.*$",
-                                        "description":"refmanifest is used for referencing manifests inside collections."
+                                        "description":"reference is used for referencing IIIF objects."
                                     }
                                 },
                                 {
@@ -501,14 +500,15 @@
                         "label": {"$ref": "#/types/lngString" },
                         "type": {
                             "type": "string",
-                            "pattern": "^Manifest"
+                            "pattern": "^Manifest$|^AnnotationPage$|^Collection$|^AnnotationCollection$"
                         },
                         "thumbnail": {
                             "type": "array",
                             "items": { "$ref": "#/classes/resource" }
                         }
                     },
-                    "required": ["id", "type", "label"]
+                    "required": ["id", "type", "label"],
+                    "not": { "required": [ "items" ] }
                 }
             ]
         },

--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -478,7 +478,7 @@
                 { "$ref": "#/types/class" },
                 {
                     "type": "object",
-                    "additionalProperties": false,
+                    "additionalProperties": true,
                     "properties": {
                         "@context": {
                             "oneOf": [


### PR DESCRIPTION
Collections can contain references to manifests as described [here](https://iiif.io/api/presentation/3.0/#51-collection) which have a limited subset of attributes. Hence, requiring the Collection to contain only fully-featured manifests is not correct see: https://github.com/iiif-prezi/iiif-prezi3/issues/8

This pull request proposes a class called `refmanifest` for describing such reference to manifests inside collections. This class has ID, label and type as required attributes while thumbnail is recommended  as described [in IIIF API 3.0](https://iiif.io/api/presentation/3.0/#51-collection).  

The same approach could be used for creating a class for reference to collections.

