### PR TITLE
Collection can have any of reference or collection object

### DIFF
--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -378,12 +378,12 @@
                         "behavior": { "$ref": "#/classes/behavior" },
                         "partOf": { "$ref": "#/classes/partOf" },
                         "items": {
-                            "type": "array",
-                            "items": {
-                              "oneOf": [
-                                { "$ref": "#/classes/manifest" },
-                                { "$ref": "#/classes/collection" }
-                              ]
+                            "type": "array",	
+                            "items": {	
+                            "anyOf": [
+                              { "$ref": "#/classes/reference" },
+                              { "$ref": "#/classes/collection" }
+                            ]
                             }
                         },
                         "annotations": {
@@ -469,6 +469,28 @@
                         }
                     },
                     "required": ["id", "type", "label"]
+                }
+            ]
+        },
+        "reference": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "id": { "$ref": "#/types/id" },
+                        "label": {"$ref": "#/types/lngString" },
+                        "type": {
+                            "type": "string",
+                            "pattern": "^Manifest$|^AnnotationPage$|^Collection$|^AnnotationCollection$|^Canvas$|^Range$"
+                        },
+                        "thumbnail": {
+                            "type": "array",
+                            "items": { "$ref": "#/classes/resource" }
+                        }
+                    },
+                    "required": ["id", "type", "label"],
+                    "not": { "required": [ "items" ] }
                 }
             ]
         },


### PR DESCRIPTION
This pull request should solve the issue https://github.com/IIIF/presentation-validator/issues/128 adding a reference class where id, label and type are mandatory, and items are not permitted (fixing the previous pull request bug in https://github.com/IIIF/presentation-validator/pull/129)

Collection items now can be collections or instances of "reference" class.