### PR TITLE
Improving debug in case of failure

### DIFF
--- a/iiif-presentation-validator.py
+++ b/iiif-presentation-validator.py
@@ -110,6 +110,11 @@ class Validator(object):
                     raise ValidationError("Manifest @id ({}) is different to the location where it was retrieved ({})".format(mf.id, url))
                 # Passed!
                 okay = 1
+            except KeyError as e:    
+                print ('Failed falidation due to:')
+                traceback.print_exc()
+                err = 'Failed due to KeyError {}, check trace for details'.format(e)
+                okay = 0
             except Exception as e:
                 # Failed
                 print ('Failed falidation due to:')

--- a/iiif-presentation-validator.py
+++ b/iiif-presentation-validator.py
@@ -112,7 +112,8 @@ class Validator(object):
                 okay = 1
             except Exception as e:
                 # Failed
-                print (e)
+                print ('Failed falidation due to:')
+                traceback.print_exc()
                 err = e
                 okay = 0
 


### PR DESCRIPTION
Relates to #139. When a KeyError exception occurs there is no feedback apart from printing '0'. Maybe could return a better error message as well. 