### PR TITLE
Make selector on SpecificResource optional.

### DIFF
--- a/fixtures/3/anno_source.json
+++ b/fixtures/3/anno_source.json
@@ -78,6 +78,7 @@
                               "format": "text/plain"
                             },
                             "target": {
+                              "type":"SpecificResource",
                               "source": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray/full/max/0/default.jpg#xywh=810,900,260,370",
                               "scope": "https://preview.iiif.io/cookbook/0326-annotating-image-layer/recipe/0326-annotating-image-layer/canvas/p1"
                             }

--- a/schema/iiif_3_0.json
+++ b/schema/iiif_3_0.json
@@ -1020,7 +1020,7 @@
                     ]
                 }
             },
-            "required": ["source", "selector"]
+            "required": ["source"]
         },
         "selector": {
             "oneOf": [


### PR DESCRIPTION
This attempts to address [Issue 179](https://github.com/IIIF/presentation-validator/issues/179) by making `selector` optional on SpecificResource. The Web Annotation Data Model suggests this should be optional (https://www.w3.org/TR/annotation-model/#purpose-for-external-web-resources) and [at least one cookbook recipe omits it](https://iiif.io/api/cookbook/recipe/0258-tagging-external-resource/).