### PR TITLE
Added scope to properties allowed to contain duplicate id

### DIFF
--- a/presentation_validator/v4/unique_ids.py
+++ b/presentation_validator/v4/unique_ids.py
@@ -3,7 +3,7 @@ import json
 from presentation_validator.model import ErrorDetail
 from presentation_validator.v3.schemavalidator import create_snippet
 
-ignore = ["target", "lookAt", "range","structures","first","last","start","source","body"]
+ignore = ["target", "lookAt", "range","structures","first","last","start","source","body","scope"]
 # create a method where you pass in a manifest and it checks to see if the id is unique
 # if it is not unique, then it should raise a validation error  
 def check(manifest):


### PR DESCRIPTION
Motivated by addition of a manifest with an annotation having a scope property: https://github.com/IIIF/3d/pull/80#issuecomment-4579371138 

This PR adds "scope" to the list which also includes "lookAt", "source" and others; properties whose values can includes ids which are defined elsewhere in the manifest